### PR TITLE
Add action nex comments

### DIFF
--- a/FF16Tools.Files/Nex/Layouts/action.layout
+++ b/FF16Tools.Files/Nex/Layouts/action.layout
@@ -200,17 +200,17 @@ set_comment|159|||Aerial Combo 3
 set_comment|160|||Lunge
 set_comment|161|||Lunge No Start
 set_comment|162|||Lunge Stab
-set_comment|163|||Lunge | Upgraded
-set_comment|164|||Lunge No Start | Upgraded
-set_comment|165|||Lunge Stab | Upgraded
-set_comment|166|||Ex Lunge | Upgraded
+set_comment|163|||Lunge (Upgraded)
+set_comment|164|||Lunge No Start (Upgraded)
+set_comment|165|||Lunge Stab (Upgraded)
+set_comment|166|||Ex Lunge (Upgraded)
 set_comment|167|||Downthrust Full
 set_comment|168|||Downthrust Slam with Sword
 set_comment|169|||Downthrust High Slam Only
 set_comment|170|||Downthrust Slam Only
-set_comment|171|||Downthrust Full | Upgraded
-set_comment|172|||Downthrust Sword with Sword | Upgraded
-set_comment|173|||Downthrust Slam Only | Upgraded
+set_comment|171|||Downthrust Full (Upgraded)
+set_comment|172|||Downthrust Sword with Sword (Upgraded)
+set_comment|173|||Downthrust Slam Only (Upgraded)
 set_comment|174|||Ground Burning Blade
 set_comment|175|||Air Burning Blade
 set_comment|176|||Nothing, Outputs "Combo 1" to Action Log
@@ -276,14 +276,14 @@ set_comment|341|||Ground Ignition Attack
 set_comment|342|||Air Ignition Attack
 set_comment|343|||Cancel
 set_comment|344|||Cancel - Airborne (Upgraded)
-set_comment|345|||Ground Ignition Intro | Upgraded
+set_comment|345|||Ground Ignition Intro (Upgraded)
 set_comment|345|||Ground Ignition Intro
-set_comment|346|||Air Ignition Intro | Upgraded
+set_comment|346|||Air Ignition Intro (Upgraded)
 set_comment|346|||Air Ignition Intro
-set_comment|347|||Ignition Travel Animation | Upgraded
-set_comment|348|||Ground Ignition Attack | Upgraded
+set_comment|347|||Ignition Travel Animation (Upgraded)
+set_comment|348|||Ground Ignition Attack (Upgraded)
 set_comment|348|||Ground Ignition Attack
-set_comment|349|||Air Ignition Attack | Upgraded
+set_comment|349|||Air Ignition Attack (Upgraded)
 set_comment|349|||Air Ignition Attack
 set_comment|353|||Phoenix - Ground Phoenix Shift
 set_comment|354|||Phoenix - Air Phoenix Shift
@@ -295,42 +295,42 @@ set_comment|359|||Phoenix - Perfect Dodge Air Attack
 set_comment|360|||Phoenix - Perfect Dodge Ground Magic Attack
 set_comment|361|||Phoenix - Perfect Dodge Air Magic Attack
 set_comment|363|||Phoenix - Rising Flames
-set_comment|364|||Phoenix - Rising Flames | Upgraded
+set_comment|364|||Phoenix - Rising Flames (Upgraded)
 set_comment|364|||Phoenix - Rising Flames
 set_comment|367|||Scarlet Cyclone
-set_comment|368|||Scarlet Cyclone | Upgraded
+set_comment|368|||Scarlet Cyclone (Upgraded)
 set_comment|368|||Scarlet Cyclone
 set_comment|369|||After Hit Scarlet Cyclone
-set_comment|370|||After Hit Scarlet Cyclone | Upgraded
+set_comment|370|||After Hit Scarlet Cyclone (Upgraded)
 set_comment|370|||After Hit Scarlet Cyclone
 set_comment|375|||Heatwave
-set_comment|376|||Heatwave | Upgraded
+set_comment|376|||Heatwave (Upgraded)
 set_comment|376|||Heatwave
 set_comment|377|||Heatwave 1 Blade Throw
 set_comment|378|||Heatwave 3 Blade Throw
 set_comment|379|||Heatwave 2 Blade Throw
 set_comment|380|||Heatwave 1 Blade Throw No Cinematic
 set_comment|385|||Rebirth
-set_comment|386|||Rebirth | Upgraded
+set_comment|386|||Rebirth (Upgraded)
 set_comment|386|||Rebirth
 set_comment|401|||Deadly Embrace
 set_comment|404|||Air Deadly Embrace
 set_comment|419|||Gouge
 set_comment|424|||Air Gouge
-set_comment|439|||Wicked Wheel | Upgraded
+set_comment|439|||Wicked Wheel (Upgraded)
 set_comment|439|||Wicked Wheel
 set_comment|440|||Wicked Wheel
 set_comment|441|||Air Wicked Wheel
-set_comment|444|||Air Wicked Wheel | Upgraded
+set_comment|444|||Air Wicked Wheel (Upgraded)
 set_comment|444|||Air Wicked Wheel
 set_comment|446|||Rooks Gambit
 set_comment|450|||Air Rooks Gambit
-set_comment|454|||Rooks Gambit | Upgraded
+set_comment|454|||Rooks Gambit (Upgraded)
 set_comment|454|||Rooks Gambit
-set_comment|460|||Air Rooks Gambit | Upgraded
+set_comment|460|||Air Rooks Gambit (Upgraded)
 set_comment|460|||Air Rooks Gambit
 set_comment|478|||Aerial Blast
-set_comment|479|||Aerial Blast | Upgraded
+set_comment|479|||Aerial Blast (Upgraded)
 set_comment|479|||Aerial Blast
 set_comment|486|||Titanic Block
 set_comment|488|||*[T]Special AC [Titan Block] End

--- a/FF16Tools.Files/Nex/Layouts/action.layout
+++ b/FF16Tools.Files/Nex/Layouts/action.layout
@@ -134,7 +134,7 @@ add_column|Unk_0x11F|byte
 //////////////////////////////////////
 // Many added from
 // https://pastebin.com/Hk7tQLDM
-// The rest joined from the `Name` or `Comment` columns of the "command" table
+// The rest are joined from the `Name` or `Comment` columns of the "command" table
 // Comments starting with * have been machine-translated from japanese
 
 set_comment|14|||Precision Dodge
@@ -142,8 +142,8 @@ set_comment|15|||Precision Dodge
 set_comment|23|||Berserker Dodge
 set_comment|25|||Grunt
 set_comment|36|||Chocobo Whistle
-set_comment|40|||*Special Attack: Garuda: Takeoff
-set_comment|42|||*Special Attack: Titan_Guard Instant Cancel
+set_comment|40|||*Special Attack: Garuda: Takeoff 
+set_comment|42|||*Special Attack: Titan_Guard Instant Cancel 
 set_comment|45|||Chocobo Whistle
 set_comment|46|||Fist Pump Taunt
 set_comment|47|||Wipe Off / Caution Taunt
@@ -244,9 +244,9 @@ set_comment|219|||Ground Magic
 set_comment|227|||Ground Charged Magic
 set_comment|228|||Air Charged Magic
 set_comment|259|||Limit Break Start Animation
-set_comment|260|||*Limit Break Interruption
+set_comment|260|||*Limit Break Interruption 
 set_comment|289|||Air Limit Break Start Animation
-set_comment|290|||*Limit Break Interruption - Airborne (Upgraded)
+set_comment|290|||*Limit Break Interruption - Airborne 
 set_comment|301|||LB Lunge Full
 set_comment|302|||LB Lunge Full(No auto target)
 set_comment|303|||LB Lunge Ex Melee Atk Only
@@ -275,16 +275,12 @@ set_comment|340|||Ignition Travel Animation
 set_comment|341|||Ground Ignition Attack
 set_comment|342|||Air Ignition Attack
 set_comment|343|||Cancel
-set_comment|344|||Cancel - Airborne (Upgraded)
+set_comment|344|||Cancel - Airborne
 set_comment|345|||Ground Ignition Intro (Upgraded)
-set_comment|345|||Ground Ignition Intro
 set_comment|346|||Air Ignition Intro (Upgraded)
-set_comment|346|||Air Ignition Intro
 set_comment|347|||Ignition Travel Animation (Upgraded)
 set_comment|348|||Ground Ignition Attack (Upgraded)
-set_comment|348|||Ground Ignition Attack
 set_comment|349|||Air Ignition Attack (Upgraded)
-set_comment|349|||Air Ignition Attack
 set_comment|353|||Phoenix - Ground Phoenix Shift
 set_comment|354|||Phoenix - Air Phoenix Shift
 set_comment|355|||Phoenix - Phoenix Shift
@@ -296,48 +292,38 @@ set_comment|360|||Phoenix - Perfect Dodge Ground Magic Attack
 set_comment|361|||Phoenix - Perfect Dodge Air Magic Attack
 set_comment|363|||Phoenix - Rising Flames
 set_comment|364|||Phoenix - Rising Flames (Upgraded)
-set_comment|364|||Phoenix - Rising Flames
 set_comment|367|||Scarlet Cyclone
 set_comment|368|||Scarlet Cyclone (Upgraded)
-set_comment|368|||Scarlet Cyclone
 set_comment|369|||After Hit Scarlet Cyclone
 set_comment|370|||After Hit Scarlet Cyclone (Upgraded)
-set_comment|370|||After Hit Scarlet Cyclone
 set_comment|375|||Heatwave
 set_comment|376|||Heatwave (Upgraded)
-set_comment|376|||Heatwave
 set_comment|377|||Heatwave 1 Blade Throw
 set_comment|378|||Heatwave 3 Blade Throw
-set_comment|379|||Heatwave 2 Blade Throw
+set_comment|379|||Heatwave 2 Blade Throw 
 set_comment|380|||Heatwave 1 Blade Throw No Cinematic
 set_comment|385|||Rebirth
 set_comment|386|||Rebirth (Upgraded)
-set_comment|386|||Rebirth
 set_comment|401|||Deadly Embrace
 set_comment|404|||Air Deadly Embrace
 set_comment|419|||Gouge
 set_comment|424|||Air Gouge
 set_comment|439|||Wicked Wheel (Upgraded)
-set_comment|439|||Wicked Wheel
 set_comment|440|||Wicked Wheel
 set_comment|441|||Air Wicked Wheel
 set_comment|444|||Air Wicked Wheel (Upgraded)
-set_comment|444|||Air Wicked Wheel
 set_comment|446|||Rooks Gambit
 set_comment|450|||Air Rooks Gambit
 set_comment|454|||Rooks Gambit (Upgraded)
-set_comment|454|||Rooks Gambit
 set_comment|460|||Air Rooks Gambit (Upgraded)
-set_comment|460|||Air Rooks Gambit
 set_comment|478|||Aerial Blast
 set_comment|479|||Aerial Blast (Upgraded)
-set_comment|479|||Aerial Blast
 set_comment|486|||Titanic Block
-set_comment|488|||*[T]Special AC [Titan Block] End
-set_comment|489|||Titanic Block - Airborne (Upgraded)
-set_comment|500|||*[T]Special AC [Titan Block] End - Airborne (Upgraded)
-set_comment|507|||*[T]Special AC [Titan Block] Just Guard
-set_comment|508|||*[T]Special AC [Titan Block] Just Guard - Airborne (Upgraded)
+set_comment|488|||*[T]Special AC [Titan Block] End 
+set_comment|489|||Titanic Block - Airborne
+set_comment|500|||*[T]Special AC [Titan Block] End - Airborne 
+set_comment|507|||*[T]Special AC [Titan Block] Just Guard 
+set_comment|508|||*[T]Special AC [Titan Block] Just Guard - Airborne 
 set_comment|520|||Windup Start Animation
 set_comment|522|||Windup Charged Stance
 set_comment|524|||Windup Slam No Animation No Damage
@@ -347,24 +333,24 @@ set_comment|530|||Windup Charged Instant
 set_comment|532|||Windup Precision Instant
 set_comment|534|||Cancel
 set_comment|536|||Upheaval
-set_comment|538|||*[T]Skill 02 [Seismic Wave] Charge Complete
+set_comment|538|||*[T]Skill 02 [Seismic Wave] Charge Complete 
 set_comment|540|||Cancel
 set_comment|541|||Cancel
-set_comment|542|||*Upheaval - Airborne *AND* [T]Skill 02 [Seismic Wave] Airborne: Start - Airborne (Upgraded)
-set_comment|546|||*[T]Skill 02 [Seismic Wave] Airborne: Start - Airborne
-set_comment|550|||*[T]Skill 02 [Seismic Wave] Lv1
-set_comment|551|||*[T]Skill 02 [Seismic Wave] Lv2
-set_comment|552|||*[T]Skill 02 [Seismic Wave] Lv3
-set_comment|553|||*[T]Skill 02 [Seismic Wave] Lv1 (Upgraded)
-set_comment|554|||*[T]Skill 02 [Seismic Wave] Lv2 (Upgraded)
-set_comment|555|||*[T]Skill 02 [Seismic Wave] Lv3 (Upgraded)
+set_comment|542|||*Upheaval - Airborne *AND* [T]Skill 02 [Seismic Wave] Airborne: Start - Airborne 
+set_comment|546|||*[T]Skill 02 [Seismic Wave] Airborne: Start - Airborne (Upgraded) 
+set_comment|550|||*[T]Skill 02 [Seismic Wave] Lv1 
+set_comment|551|||*[T]Skill 02 [Seismic Wave] Lv2 
+set_comment|552|||*[T]Skill 02 [Seismic Wave] Lv3 
+set_comment|553|||*[T]Skill 02 [Seismic Wave] Lv1 (Upgraded) 
+set_comment|554|||*[T]Skill 02 [Seismic Wave] Lv2 (Upgraded) 
+set_comment|555|||*[T]Skill 02 [Seismic Wave] Lv3 (Upgraded) 
 set_comment|578|||Raging Fists
 set_comment|585|||Raging Fists (Upgraded)
 set_comment|611|||Earthen Fury
 set_comment|612|||Earthen Fury (Upgraded)
-set_comment|619|||*[R]Special AC [Multiple Lock] Auto Attack
+set_comment|619|||*[R]Special AC [Multiple Lock] Auto Attack 
 set_comment|621|||Blind Justice
-set_comment|622|||Blind Justice - Airborne (Upgraded)
+set_comment|622|||Blind Justice - Airborne
 set_comment|624|||Cancel
 set_comment|635|||Pile Drive
 set_comment|636|||Pile Drive (Upgraded)
@@ -372,8 +358,8 @@ set_comment|639|||Thunderstorm
 set_comment|640|||Thunderstorm (Upgraded)
 set_comment|643|||Lightning Rod
 set_comment|644|||Lightning Rod (Upgraded)
-set_comment|645|||*[R]Skill 03: Shock Discharge Magic Ball
-set_comment|646|||*[R]Skill 03: Shock Discharge Magic Ball (Upgraded)
+set_comment|645|||*[R]Skill 03: Shock Discharge Magic Ball 
+set_comment|646|||*[R]Skill 03: Shock Discharge Magic Ball (Upgraded) 
 set_comment|649|||Judgment Bolt
 set_comment|650|||Judgment Bolt (Upgraded)
 set_comment|703|||Air Cold Snap
@@ -383,35 +369,35 @@ set_comment|715|||Air Frostbite
 set_comment|718|||Air Permafrost
 set_comment|719|||Ground Permafrost
 set_comment|729|||Ice Age
-set_comment|731|||*[S]Skill 01 [Icicle Wave] Charge Complete
-set_comment|733|||*[S]Skill 01 [Icicle Wave] Weak Shot
-set_comment|734|||*[S]Skill 01 [Icicle Wave] Strong Shot
-set_comment|735|||*[S]Skill 01 [Icicle Wave] Just Shot
+set_comment|731|||*[S]Skill 01 [Icicle Wave] Charge Complete 
+set_comment|733|||*[S]Skill 01 [Icicle Wave] Weak Shot 
+set_comment|734|||*[S]Skill 01 [Icicle Wave] Strong Shot 
+set_comment|735|||*[S]Skill 01 [Icicle Wave] Just Shot 
 set_comment|736|||Cancel
 set_comment|745|||Mesmerize
-set_comment|746|||Mesmerize - Airborne (Upgraded)
-set_comment|747|||Mesmerize
-set_comment|748|||Mesmerize - Airborne
+set_comment|746|||Mesmerize - Airborne
+set_comment|747|||Mesmerize (Upgraded)
+set_comment|748|||Mesmerize - Airborne (Upgraded)
 set_comment|754|||Rime
-set_comment|755|||Rime - Airborne (Upgraded)
+set_comment|755|||Rime - Airborne
 set_comment|756|||Rime
-set_comment|757|||Rime - Airborne (Upgraded)
-set_comment|759|||Rime
-set_comment|760|||Rime - Airborne
-set_comment|761|||Rime
-set_comment|762|||Rime - Airborne
+set_comment|757|||Rime - Airborne
+set_comment|759|||Rime (Upgraded)
+set_comment|760|||Rime - Airborne (Upgraded)
+set_comment|761|||Rime (Upgraded)
+set_comment|762|||Rime - Airborne (Upgraded)
 set_comment|765|||Diamond Dust
 set_comment|766|||Diamond Dust (Upgraded)
 set_comment|773|||Wings of Light
-set_comment|774|||Wings of Light - Airborne (Upgraded)
+set_comment|774|||Wings of Light - Airborne
 set_comment|776|||Megaflare
-set_comment|777|||*Summoned Beast Action: Megaflare: Activation: Level 2
-set_comment|800|||*Summoned Beast Action: Megaflare: Activation: Level 3
-set_comment|801|||*Summoned Beast Action: Megaflare: Activation: Level 4
-set_comment|802|||Megaflare - Airborne (Upgraded)
-set_comment|803|||*Summoned Beast Action: Megaflare: Activation: Level 2 - Airborne (Upgraded)
-set_comment|804|||*Summoned Beast Action: Megaflare: Activation: Level 3 - Airborne (Upgraded)
-set_comment|805|||*Summoned Beast Action: Megaflare: Activation: Level 4 - Airborne (Upgraded)
+set_comment|777|||*Summoned Beast Action: Megaflare: Activation: Level 2 
+set_comment|800|||*Summoned Beast Action: Megaflare: Activation: Level 3 
+set_comment|801|||*Summoned Beast Action: Megaflare: Activation: Level 4 
+set_comment|802|||Megaflare - Airborne
+set_comment|803|||*Summoned Beast Action: Megaflare: Activation: Level 2 - Airborne 
+set_comment|804|||*Summoned Beast Action: Megaflare: Activation: Level 3 - Airborne 
+set_comment|805|||*Summoned Beast Action: Megaflare: Activation: Level 4 - Airborne 
 set_comment|810|||Cancel
 set_comment|823|||Impulse
 set_comment|824|||Impulse (Upgraded)
@@ -422,7 +408,7 @@ set_comment|838|||Satellite
 set_comment|839|||Satellite (Upgraded)
 set_comment|842|||Gigaflare
 set_comment|845|||Gigaflare (Upgraded)
-set_comment|848|||Cancel
+set_comment|848|||Cancel *AND* Cancel (Upgraded)
 set_comment|871|||Dark Aerial Strike
 set_comment|872|||Dark Aerial Strike (No Action Log; No VFX)
 set_comment|873|||Dark Aerial Strike (No Action Log; No VFX)
@@ -442,33 +428,33 @@ set_comment|901|||Zantetsuken Lvl 2
 set_comment|902|||Zantetsuken Lvl 3
 set_comment|910|||Arm of Darkness - Airborne
 set_comment|911|||Sheathe - Airborne
-set_comment|914|||Arm of Darkness (Upgraded)
-set_comment|915|||Sheathe (Upgraded)
+set_comment|914|||Arm of Darkness
+set_comment|915|||Sheathe
 set_comment|916|||Gungnir
 set_comment|921|||Cancel
 set_comment|928|||Heaven's Cloud
 set_comment|951|||Rift Slip
-set_comment|952|||Rift Slip - Airborne (Upgraded)
+set_comment|952|||Rift Slip - Airborne
 set_comment|966|||Dancing Steel
 set_comment|970|||Dancing Steel (Upgraded)
 set_comment|1014|||Serpent's Cry
 set_comment|1015|||Cancel
-set_comment|1016|||Serpent's Cry - Airborne (Upgraded)
-set_comment|1017|||Cancel - Airborne (Upgraded)
-set_comment|1032|||*[L]Leviathan Roll
+set_comment|1016|||Serpent's Cry - Airborne
+set_comment|1017|||Cancel - Airborne
+set_comment|1032|||[L]Leviathan Roll
 set_comment|1036|||Refill
-set_comment|1038|||*[L]Special AC: Shooting Mode: Reload Complete
-set_comment|1039|||*[L]Special AC: Shooting Mode: Just Reload
-set_comment|1044|||*[L]Special AC: Shooting Mode: Shotgun Fail
+set_comment|1038|||*[L]Special AC: Shooting Mode: Reload Complete 
+set_comment|1039|||*[L]Special AC: Shooting Mode: Just Reload 
+set_comment|1044|||*[L]Special AC: Shooting Mode: Shotgun Fail 
 set_comment|1046|||Tidal Torrent
 set_comment|1053|||Charged Torrent
-set_comment|1058|||*[L]Special AC [Shooting Mode] Restart
-set_comment|1059|||*[L]Special AC [Shooting Mode] Restart - Airborne (Upgraded)
-set_comment|1061|||*[L]Special AC [Shooting Mode] Grenade: Out of Ammo
-set_comment|1062|||*[L]Special AC: Shooting Mode: Grenade
+set_comment|1058|||*[L]Special AC [Shooting Mode] Restart 
+set_comment|1059|||*[L]Special AC [Shooting Mode] Restart - Airborne 
+set_comment|1061|||*[L]Special AC [Shooting Mode] Grenade: Out of Ammo 
+set_comment|1062|||*[L]Special AC: Shooting Mode: Grenade 
 set_comment|1065|||Tidal Stream
 set_comment|1069|||Charged Stream
-set_comment|1073|||*[L]Special AC [Shooting Mode] Laser: Out of Ammo
+set_comment|1073|||*[L]Special AC [Shooting Mode] Laser: Out of Ammo 
 set_comment|1077|||Deluge
 set_comment|1078|||Deluge (Upgraded)
 set_comment|1082|||Cancel
@@ -476,135 +462,135 @@ set_comment|1083|||Cancel
 set_comment|1090|||Cross Swell
 set_comment|1091|||Cross Swell (Upgraded)
 set_comment|1094|||Abyssal Tear
-set_comment|1095|||Abyssal Tear - Airborne (Upgraded)
+set_comment|1095|||Abyssal Tear - Airborne
 set_comment|1096|||Vent
 set_comment|1097|||Vent
-set_comment|1098|||Vent - Airborne (Upgraded)
-set_comment|1099|||Vent - Airborne (Upgraded)
+set_comment|1098|||Vent - Airborne
+set_comment|1099|||Vent - Airborne
 set_comment|1123|||Tsunami
 set_comment|1124|||Tsunami (Upgraded)
 set_comment|1132|||Ascension
 set_comment|1133|||Descend
-set_comment|1134|||Ascension - Airborne (Upgraded)
-set_comment|1135|||Descend - Airborne (Upgraded)
-set_comment|1139|||*[U]Special AC [Ultima Mode] Restart
-set_comment|1140|||*[U]Special AC [Ultima Mode] Restart - Airborne (Upgraded)
-set_comment|1176|||*[O]Special AC [Wing Rush]
-set_comment|1178|||*[U]Special AC [Wing Rush] End
-set_comment|1179|||*[O]Special AC [Wing Rush] - Airborne (Upgraded)
-set_comment|1181|||*[U]Special AC [Wing Rush] End - Airborne (Upgraded)
+set_comment|1134|||Ascension - Airborne
+set_comment|1135|||Descend - Airborne
+set_comment|1139|||*[U]Special AC [Ultima Mode] Restart 
+set_comment|1140|||*[U]Special AC [Ultima Mode] Restart - Airborne 
+set_comment|1176|||*[O]Special AC [Wing Rush] 
+set_comment|1178|||*[U]Special AC [Wing Rush] End 
+set_comment|1179|||*[O]Special AC [Wing Rush] - Airborne 
+set_comment|1181|||*[U]Special AC [Wing Rush] End - Airborne 
 set_comment|1182|||Rising Advent
-set_comment|1188|||*[U]Special AC [Wing Rush] Forced End *AND* [U]Special AC [Wing Rush] Ultima Mode Forced End
+set_comment|1188|||*[U]Special AC [Wing Rush] Ultima Mode Forced End *AND* [U]Special AC [Wing Rush] Forced End 
 set_comment|1197|||Purge
-set_comment|1198|||Purge - Airborne (Upgraded)
+set_comment|1198|||Purge - Airborne
 set_comment|1210|||Proselytize
 set_comment|1211|||Proselytize (Upgraded)
 set_comment|1212|||Proselytize - Airborne
-set_comment|1213|||Proselytize - Airborne
+set_comment|1213|||Proselytize - Airborne (Upgraded)
 set_comment|1216|||Dominion
 set_comment|1217|||Dominion (Upgraded)
 set_comment|1218|||Dominion - Airborne
-set_comment|1219|||Dominion - Airborne
+set_comment|1219|||Dominion - Airborne (Upgraded)
 set_comment|1224|||Voice of God
-set_comment|1227|||Voice of God - Airborne (Upgraded)
+set_comment|1227|||Voice of God - Airborne
 set_comment|1230|||Cancel
 set_comment|1239|||Ultimate Demise
 set_comment|1240|||Ultimate Demise (Upgraded)
 set_comment|1241|||Ultimate Demise - Airborne
-set_comment|1242|||Ultimate Demise - Airborne
+set_comment|1242|||Ultimate Demise - Airborne (Upgraded)
 set_comment|1610|||
 set_comment|1611|||Yell
-set_comment|50002|||*Phoenix: Normal Combo: 01
-set_comment|50004|||*Phoenix: Burst Combo: 01
-set_comment|50005|||*Phoenix: Reincarnation Flame
-set_comment|52062|||*Ifrit Garuda Battle: Ifrit: Triangle Single Shot
-set_comment|52063|||*Ifrit Garuda Battle: Ifrit: Circle Lunge
-set_comment|54045|||*PC Ifrit: Lunge Attack
-set_comment|54054|||*PC Ifrit: Falling Attack - Airborne
-set_comment|54057|||*PC Ifrit: Falling Attack - Airborne (Upgraded)
-set_comment|54065|||*PC Ifrit: Charge Attack
-set_comment|54066|||*PC Ifrit: Charge Attack - Airborne (Upgraded)
+set_comment|50002|||*Phoenix: Normal Combo: 01 
+set_comment|50004|||*Phoenix: Burst Combo: 01 
+set_comment|50005|||*Phoenix: Reincarnation Flame 
+set_comment|52062|||*Ifrit Garuda Battle: Ifrit: Triangle Single Shot 
+set_comment|52063|||*Ifrit Garuda Battle: Ifrit: Circle Lunge 
+set_comment|54045|||*PC Ifrit: Lunge Attack 
+set_comment|54054|||*PC Ifrit: Falling Attack - Airborne 
+set_comment|54057|||*PC Ifrit: Falling Attack - Airborne (Upgraded) 
+set_comment|54065|||*PC Ifrit: Charge Attack 
+set_comment|54066|||*PC Ifrit: Charge Attack - Airborne 
 set_comment|54068|||Fireball
-set_comment|54069|||Fireball - Airborne (Upgraded)
+set_comment|54069|||Fireball - Airborne
 set_comment|54074|||Firaball
-set_comment|54075|||Firaball - Airborne (Upgraded)
+set_comment|54075|||Firaball - Airborne
 set_comment|54077|||Brimstone
-set_comment|54079|||*PC Ifrit: Titan Technique: Loop
+set_comment|54079|||*PC Ifrit: Titan Technique: Loop 
 set_comment|54081|||Cancel
-set_comment|54082|||*PC Ifrit: Titan Technique: Activation: LV1
-set_comment|54083|||*PC Ifrit: Titan Technique: Activation: LV2
-set_comment|54084|||*PC Ifrit: Titan Technique: Activation: Just
-set_comment|54085|||Brimstone - Airborne (Upgraded)
-set_comment|54087|||*PC Ifrit: Titan Technique: Loop - Airborne (Upgraded)
-set_comment|54089|||Cancel - Airborne (Upgraded)
-set_comment|54090|||*PC Ifrit: Titan Technique: Activation: LV1 - Airborne (Upgraded)
-set_comment|54091|||*PC Ifrit: Titan Technique: Activation: LV2 - Airborne (Upgraded)
-set_comment|54092|||*PC Ifrit: Titan Technique: Activation: Just - Airborne (Upgraded)
+set_comment|54082|||*PC Ifrit: Titan Technique: Activation: LV1 
+set_comment|54083|||*PC Ifrit: Titan Technique: Activation: LV2 
+set_comment|54084|||*PC Ifrit: Titan Technique: Activation: Just 
+set_comment|54085|||Brimstone - Airborne
+set_comment|54087|||*PC Ifrit: Titan Technique: Loop - Airborne 
+set_comment|54089|||Cancel - Airborne
+set_comment|54090|||*PC Ifrit: Titan Technique: Activation: LV1 - Airborne 
+set_comment|54091|||*PC Ifrit: Titan Technique: Activation: LV2 - Airborne 
+set_comment|54092|||*PC Ifrit: Titan Technique: Activation: Just - Airborne 
 set_comment|54094|||Spitflare
 set_comment|54096|||Cancel
-set_comment|54097|||Spitflare - Airborne (Upgraded)
-set_comment|54099|||Cancel - Airborne (Upgraded)
+set_comment|54097|||Spitflare - Airborne
+set_comment|54099|||Cancel - Airborne
 set_comment|54101|||Wildfire
-set_comment|54102|||Wildfire - Airborne (Upgraded)
-set_comment|54104|||*PC Ifrit: Circle Dash: End
-set_comment|54105|||*PC Ifrit: Circle Dash: End - Airborne (Upgraded)
-set_comment|54108|||*PC Ifrit: Titan P2: Normal Shot *AND* PC Ifrit: Titan P2: Normal Shot - Airborne
-set_comment|54113|||*PC Ifrit: Titan P2: Charge Shot: Fire
-set_comment|54114|||*PC Ifrit: Titan P2: Charge Shot: Fire - Airborne (Upgraded)
-set_comment|54123|||*PC Ifrit: Titan P4: Normal Shot - Airborne
-set_comment|54128|||*PC Ifrit: Titan P4: Charge Shot: Fire - Airborne
-set_comment|54148|||*PC Ifrit: Titan P5: Lunge Attack - Airborne
-set_comment|54157|||*PC Ifrit: Titan P5: Charge Attack - Airborne
+set_comment|54102|||Wildfire - Airborne
+set_comment|54104|||*PC Ifrit: Circle Dash: End 
+set_comment|54105|||*PC Ifrit: Circle Dash: End - Airborne 
+set_comment|54108|||*PC Ifrit: Titan P2: Normal Shot *AND* PC Ifrit: Titan P2: Normal Shot - Airborne 
+set_comment|54113|||*PC Ifrit: Titan P2: Charge Shot: Fire 
+set_comment|54114|||*PC Ifrit: Titan P2: Charge Shot: Fire - Airborne 
+set_comment|54123|||*PC Ifrit: Titan P4: Normal Shot - Airborne 
+set_comment|54128|||*PC Ifrit: Titan P4: Charge Shot: Fire - Airborne 
+set_comment|54148|||*PC Ifrit: Titan P5: Lunge Attack - Airborne 
+set_comment|54157|||*PC Ifrit: Titan P5: Charge Attack - Airborne 
 set_comment|54158|||Firaball - Airborne
 set_comment|54160|||Brimstone - Airborne
-set_comment|54162|||*PC Ifrit: Titan P5: Titan Technique: Loop - Airborne
+set_comment|54162|||*PC Ifrit: Titan P5: Titan Technique: Loop - Airborne 
 set_comment|54164|||Cancel - Airborne
-set_comment|54165|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV1 - Airborne
-set_comment|54166|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV2 - Airborne
-set_comment|54167|||*PC Ifrit: Titan P5: Titan Technique: Activation: Just - Airborne
+set_comment|54165|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV1 - Airborne 
+set_comment|54166|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV2 - Airborne 
+set_comment|54167|||*PC Ifrit: Titan P5: Titan Technique: Activation: Just - Airborne 
 set_comment|54169|||Spitflare - Airborne
 set_comment|54171|||Cancel - Airborne
 set_comment|54173|||Wildfire - Airborne
-set_comment|54175|||*PC Ifrit: Titan P5: Circle Dash: End - Airborne
-set_comment|54179|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start
-set_comment|54181|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop
+set_comment|54175|||*PC Ifrit: Titan P5: Circle Dash: End - Airborne 
+set_comment|54179|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start 
+set_comment|54181|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop 
 set_comment|54183|||Cancel
-set_comment|54184|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1
-set_comment|54185|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2
-set_comment|54186|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just
-set_comment|54187|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start - Airborne (Upgraded)
-set_comment|54189|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop - Airborne (Upgraded)
-set_comment|54191|||Cancel - Airborne (Upgraded)
-set_comment|54192|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1 - Airborne (Upgraded)
-set_comment|54193|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2 - Airborne (Upgraded)
-set_comment|54194|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just - Airborne (Upgraded)
+set_comment|54184|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1 
+set_comment|54185|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2 
+set_comment|54186|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just 
+set_comment|54187|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start - Airborne 
+set_comment|54189|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop - Airborne 
+set_comment|54191|||Cancel - Airborne
+set_comment|54192|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1 - Airborne 
+set_comment|54193|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2 - Airborne 
+set_comment|54194|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just - Airborne 
 set_comment|54198|||Cancel
-set_comment|54201|||Cancel - Airborne (Upgraded)
-set_comment|54227|||*PC Ifrit: Leviathan P1: Lunge Attack
-set_comment|54236|||*PC Ifrit: Leviathan P1: Charge Attack
+set_comment|54201|||Cancel - Airborne
+set_comment|54227|||*PC Ifrit: Leviathan P1: Lunge Attack 
+set_comment|54236|||*PC Ifrit: Leviathan P1: Charge Attack 
 set_comment|54237|||Firaball
 set_comment|54239|||Brimstone
-set_comment|54241|||*PC Ifrit: Leviathan P1: Titan Technique: Loop
+set_comment|54241|||*PC Ifrit: Leviathan P1: Titan Technique: Loop 
 set_comment|54243|||Cancel
-set_comment|54244|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV1
-set_comment|54245|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV2
-set_comment|54246|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: Just
+set_comment|54244|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV1 
+set_comment|54245|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV2 
+set_comment|54246|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: Just 
 set_comment|54249|||Spitflare
 set_comment|54251|||Cancel
 set_comment|54253|||Wildfire
-set_comment|54255|||*PC Ifrit: Leviathan P1: Circle Dash: End
-set_comment|59020|||*Ifrit Risen: Lunge Attack
-set_comment|59029|||*Ifrit Risen: Charge Attack
+set_comment|54255|||*PC Ifrit: Leviathan P1: Circle Dash: End 
+set_comment|59020|||*Ifrit Risen: Lunge Attack 
+set_comment|59029|||*Ifrit Risen: Charge Attack 
 set_comment|59031|||Fireballs
 set_comment|59033|||Firabeam
 set_comment|59035|||Brimstone
-set_comment|59037|||*Ifrit Risen: Titan Technique: Charge Complete
+set_comment|59037|||*Ifrit Risen: Titan Technique: Charge Complete 
 set_comment|59039|||Cancel
-set_comment|59040|||*Ifrit Risen: Titan Technique: Activation: LV1
-set_comment|59041|||*Ifrit Risen: Titan Technique: Activation: LV2
-set_comment|59042|||*Ifrit Risen: Titan Technique: Activation: Just
+set_comment|59040|||*Ifrit Risen: Titan Technique: Activation: LV1 
+set_comment|59041|||*Ifrit Risen: Titan Technique: Activation: LV2 
+set_comment|59042|||*Ifrit Risen: Titan Technique: Activation: Just 
 set_comment|59044|||Spitflare
 set_comment|59046|||Cancel
 set_comment|59048|||Wildfire
-set_comment|59050|||*Ifrit Risen: Circle Dash: End
+set_comment|59050|||*Ifrit Risen: Circle Dash: End 
 set_comment|59052|||Lightspeed

--- a/FF16Tools.Files/Nex/Layouts/action.layout
+++ b/FF16Tools.Files/Nex/Layouts/action.layout
@@ -134,12 +134,16 @@ add_column|Unk_0x11F|byte
 //////////////////////////////////////
 // Many added from
 // https://pastebin.com/Hk7tQLDM
+// The rest joined from the `Name` or `Comment` columns of the "command" table
+// Comments starting with * have been machine-translated from japanese
 
 set_comment|14|||Precision Dodge
 set_comment|15|||Precision Dodge
 set_comment|23|||Berserker Dodge
 set_comment|25|||Grunt
 set_comment|36|||Chocobo Whistle
+set_comment|40|||*Special Attack: Garuda: Takeoff
+set_comment|42|||*Special Attack: Titan_Guard Instant Cancel
 set_comment|45|||Chocobo Whistle
 set_comment|46|||Fist Pump Taunt
 set_comment|47|||Wipe Off / Caution Taunt
@@ -240,7 +244,9 @@ set_comment|219|||Ground Magic
 set_comment|227|||Ground Charged Magic
 set_comment|228|||Air Charged Magic
 set_comment|259|||Limit Break Start Animation
+set_comment|260|||*Limit Break Interruption
 set_comment|289|||Air Limit Break Start Animation
+set_comment|290|||*Limit Break Interruption - Airborne (Upgraded)
 set_comment|301|||LB Lunge Full
 set_comment|302|||LB Lunge Full(No auto target)
 set_comment|303|||LB Lunge Ex Melee Atk Only
@@ -268,11 +274,17 @@ set_comment|339|||Air Ignition Intro
 set_comment|340|||Ignition Travel Animation
 set_comment|341|||Ground Ignition Attack
 set_comment|342|||Air Ignition Attack
+set_comment|343|||Cancel
+set_comment|344|||Cancel - Airborne (Upgraded)
 set_comment|345|||Ground Ignition Intro | Upgraded
+set_comment|345|||Ground Ignition Intro
 set_comment|346|||Air Ignition Intro | Upgraded
+set_comment|346|||Air Ignition Intro
 set_comment|347|||Ignition Travel Animation | Upgraded
 set_comment|348|||Ground Ignition Attack | Upgraded
+set_comment|348|||Ground Ignition Attack
 set_comment|349|||Air Ignition Attack | Upgraded
+set_comment|349|||Air Ignition Attack
 set_comment|353|||Phoenix - Ground Phoenix Shift
 set_comment|354|||Phoenix - Air Phoenix Shift
 set_comment|355|||Phoenix - Phoenix Shift
@@ -284,32 +296,48 @@ set_comment|360|||Phoenix - Perfect Dodge Ground Magic Attack
 set_comment|361|||Phoenix - Perfect Dodge Air Magic Attack
 set_comment|363|||Phoenix - Rising Flames
 set_comment|364|||Phoenix - Rising Flames | Upgraded
+set_comment|364|||Phoenix - Rising Flames
 set_comment|367|||Scarlet Cyclone
 set_comment|368|||Scarlet Cyclone | Upgraded
+set_comment|368|||Scarlet Cyclone
 set_comment|369|||After Hit Scarlet Cyclone
 set_comment|370|||After Hit Scarlet Cyclone | Upgraded
+set_comment|370|||After Hit Scarlet Cyclone
 set_comment|375|||Heatwave
 set_comment|376|||Heatwave | Upgraded
+set_comment|376|||Heatwave
 set_comment|377|||Heatwave 1 Blade Throw
 set_comment|378|||Heatwave 3 Blade Throw
-set_comment|379|||Heatwave 2 Blade Throw 
+set_comment|379|||Heatwave 2 Blade Throw
 set_comment|380|||Heatwave 1 Blade Throw No Cinematic
 set_comment|385|||Rebirth
 set_comment|386|||Rebirth | Upgraded
+set_comment|386|||Rebirth
 set_comment|401|||Deadly Embrace
 set_comment|404|||Air Deadly Embrace
 set_comment|419|||Gouge
 set_comment|424|||Air Gouge
 set_comment|439|||Wicked Wheel | Upgraded
+set_comment|439|||Wicked Wheel
 set_comment|440|||Wicked Wheel
 set_comment|441|||Air Wicked Wheel
 set_comment|444|||Air Wicked Wheel | Upgraded
+set_comment|444|||Air Wicked Wheel
 set_comment|446|||Rooks Gambit
 set_comment|450|||Air Rooks Gambit
 set_comment|454|||Rooks Gambit | Upgraded
+set_comment|454|||Rooks Gambit
 set_comment|460|||Air Rooks Gambit | Upgraded
+set_comment|460|||Air Rooks Gambit
 set_comment|478|||Aerial Blast
 set_comment|479|||Aerial Blast | Upgraded
+set_comment|479|||Aerial Blast
+set_comment|486|||Titanic Block
+set_comment|488|||*[T]Special AC [Titan Block] End
+set_comment|489|||Titanic Block - Airborne (Upgraded)
+set_comment|500|||*[T]Special AC [Titan Block] End - Airborne (Upgraded)
+set_comment|507|||*[T]Special AC [Titan Block] Just Guard
+set_comment|508|||*[T]Special AC [Titan Block] Just Guard - Airborne (Upgraded)
 set_comment|520|||Windup Start Animation
 set_comment|522|||Windup Charged Stance
 set_comment|524|||Windup Slam No Animation No Damage
@@ -317,12 +345,84 @@ set_comment|526|||Windup Mid Swing Stance
 set_comment|528|||Windup Low Charge Instant
 set_comment|530|||Windup Charged Instant
 set_comment|532|||Windup Precision Instant
+set_comment|534|||Cancel
+set_comment|536|||Upheaval
+set_comment|538|||*[T]Skill 02 [Seismic Wave] Charge Complete
+set_comment|540|||Cancel
+set_comment|541|||Cancel
+set_comment|542|||*Upheaval - Airborne *AND* [T]Skill 02 [Seismic Wave] Airborne: Start - Airborne (Upgraded)
+set_comment|546|||*[T]Skill 02 [Seismic Wave] Airborne: Start - Airborne
+set_comment|550|||*[T]Skill 02 [Seismic Wave] Lv1
+set_comment|551|||*[T]Skill 02 [Seismic Wave] Lv2
+set_comment|552|||*[T]Skill 02 [Seismic Wave] Lv3
+set_comment|553|||*[T]Skill 02 [Seismic Wave] Lv1 (Upgraded)
+set_comment|554|||*[T]Skill 02 [Seismic Wave] Lv2 (Upgraded)
+set_comment|555|||*[T]Skill 02 [Seismic Wave] Lv3 (Upgraded)
+set_comment|578|||Raging Fists
+set_comment|585|||Raging Fists (Upgraded)
+set_comment|611|||Earthen Fury
+set_comment|612|||Earthen Fury (Upgraded)
+set_comment|619|||*[R]Special AC [Multiple Lock] Auto Attack
+set_comment|621|||Blind Justice
+set_comment|622|||Blind Justice - Airborne (Upgraded)
+set_comment|624|||Cancel
+set_comment|635|||Pile Drive
+set_comment|636|||Pile Drive (Upgraded)
+set_comment|639|||Thunderstorm
+set_comment|640|||Thunderstorm (Upgraded)
+set_comment|643|||Lightning Rod
+set_comment|644|||Lightning Rod (Upgraded)
+set_comment|645|||*[R]Skill 03: Shock Discharge Magic Ball
+set_comment|646|||*[R]Skill 03: Shock Discharge Magic Ball (Upgraded)
+set_comment|649|||Judgment Bolt
+set_comment|650|||Judgment Bolt (Upgraded)
 set_comment|703|||Air Cold Snap
 set_comment|704|||Ground Cold Snap
 set_comment|714|||Frostbite
 set_comment|715|||Air Frostbite
 set_comment|718|||Air Permafrost
 set_comment|719|||Ground Permafrost
+set_comment|729|||Ice Age
+set_comment|731|||*[S]Skill 01 [Icicle Wave] Charge Complete
+set_comment|733|||*[S]Skill 01 [Icicle Wave] Weak Shot
+set_comment|734|||*[S]Skill 01 [Icicle Wave] Strong Shot
+set_comment|735|||*[S]Skill 01 [Icicle Wave] Just Shot
+set_comment|736|||Cancel
+set_comment|745|||Mesmerize
+set_comment|746|||Mesmerize - Airborne (Upgraded)
+set_comment|747|||Mesmerize
+set_comment|748|||Mesmerize - Airborne
+set_comment|754|||Rime
+set_comment|755|||Rime - Airborne (Upgraded)
+set_comment|756|||Rime
+set_comment|757|||Rime - Airborne (Upgraded)
+set_comment|759|||Rime
+set_comment|760|||Rime - Airborne
+set_comment|761|||Rime
+set_comment|762|||Rime - Airborne
+set_comment|765|||Diamond Dust
+set_comment|766|||Diamond Dust (Upgraded)
+set_comment|773|||Wings of Light
+set_comment|774|||Wings of Light - Airborne (Upgraded)
+set_comment|776|||Megaflare
+set_comment|777|||*Summoned Beast Action: Megaflare: Activation: Level 2
+set_comment|800|||*Summoned Beast Action: Megaflare: Activation: Level 3
+set_comment|801|||*Summoned Beast Action: Megaflare: Activation: Level 4
+set_comment|802|||Megaflare - Airborne (Upgraded)
+set_comment|803|||*Summoned Beast Action: Megaflare: Activation: Level 2 - Airborne (Upgraded)
+set_comment|804|||*Summoned Beast Action: Megaflare: Activation: Level 3 - Airborne (Upgraded)
+set_comment|805|||*Summoned Beast Action: Megaflare: Activation: Level 4 - Airborne (Upgraded)
+set_comment|810|||Cancel
+set_comment|823|||Impulse
+set_comment|824|||Impulse (Upgraded)
+set_comment|829|||Flare Breath
+set_comment|830|||Flare Breath (Upgraded)
+set_comment|833|||Cancel
+set_comment|838|||Satellite
+set_comment|839|||Satellite (Upgraded)
+set_comment|842|||Gigaflare
+set_comment|845|||Gigaflare (Upgraded)
+set_comment|848|||Cancel
 set_comment|871|||Dark Aerial Strike
 set_comment|872|||Dark Aerial Strike (No Action Log; No VFX)
 set_comment|873|||Dark Aerial Strike (No Action Log; No VFX)
@@ -340,5 +440,171 @@ set_comment|899|||Zantetsuken Lvl 1
 set_comment|900|||Zantetsuken Lvl 1
 set_comment|901|||Zantetsuken Lvl 2
 set_comment|902|||Zantetsuken Lvl 3
+set_comment|910|||Arm of Darkness - Airborne
+set_comment|911|||Sheathe - Airborne
+set_comment|914|||Arm of Darkness (Upgraded)
+set_comment|915|||Sheathe (Upgraded)
+set_comment|916|||Gungnir
+set_comment|921|||Cancel
+set_comment|928|||Heaven's Cloud
+set_comment|951|||Rift Slip
+set_comment|952|||Rift Slip - Airborne (Upgraded)
+set_comment|966|||Dancing Steel
+set_comment|970|||Dancing Steel (Upgraded)
+set_comment|1014|||Serpent's Cry
+set_comment|1015|||Cancel
+set_comment|1016|||Serpent's Cry - Airborne (Upgraded)
+set_comment|1017|||Cancel - Airborne (Upgraded)
+set_comment|1032|||*[L]Leviathan Roll
+set_comment|1036|||Refill
+set_comment|1038|||*[L]Special AC: Shooting Mode: Reload Complete
+set_comment|1039|||*[L]Special AC: Shooting Mode: Just Reload
+set_comment|1044|||*[L]Special AC: Shooting Mode: Shotgun Fail
+set_comment|1046|||Tidal Torrent
+set_comment|1053|||Charged Torrent
+set_comment|1058|||*[L]Special AC [Shooting Mode] Restart
+set_comment|1059|||*[L]Special AC [Shooting Mode] Restart - Airborne (Upgraded)
+set_comment|1061|||*[L]Special AC [Shooting Mode] Grenade: Out of Ammo
+set_comment|1062|||*[L]Special AC: Shooting Mode: Grenade
+set_comment|1065|||Tidal Stream
+set_comment|1069|||Charged Stream
+set_comment|1073|||*[L]Special AC [Shooting Mode] Laser: Out of Ammo
+set_comment|1077|||Deluge
+set_comment|1078|||Deluge (Upgraded)
+set_comment|1082|||Cancel
+set_comment|1083|||Cancel
+set_comment|1090|||Cross Swell
+set_comment|1091|||Cross Swell (Upgraded)
+set_comment|1094|||Abyssal Tear
+set_comment|1095|||Abyssal Tear - Airborne (Upgraded)
+set_comment|1096|||Vent
+set_comment|1097|||Vent
+set_comment|1098|||Vent - Airborne (Upgraded)
+set_comment|1099|||Vent - Airborne (Upgraded)
+set_comment|1123|||Tsunami
+set_comment|1124|||Tsunami (Upgraded)
+set_comment|1132|||Ascension
+set_comment|1133|||Descend
+set_comment|1134|||Ascension - Airborne (Upgraded)
+set_comment|1135|||Descend - Airborne (Upgraded)
+set_comment|1139|||*[U]Special AC [Ultima Mode] Restart
+set_comment|1140|||*[U]Special AC [Ultima Mode] Restart - Airborne (Upgraded)
+set_comment|1176|||*[O]Special AC [Wing Rush]
+set_comment|1178|||*[U]Special AC [Wing Rush] End
+set_comment|1179|||*[O]Special AC [Wing Rush] - Airborne (Upgraded)
+set_comment|1181|||*[U]Special AC [Wing Rush] End - Airborne (Upgraded)
+set_comment|1182|||Rising Advent
+set_comment|1188|||*[U]Special AC [Wing Rush] Forced End *AND* [U]Special AC [Wing Rush] Ultima Mode Forced End
+set_comment|1197|||Purge
+set_comment|1198|||Purge - Airborne (Upgraded)
+set_comment|1210|||Proselytize
+set_comment|1211|||Proselytize (Upgraded)
+set_comment|1212|||Proselytize - Airborne
+set_comment|1213|||Proselytize - Airborne
+set_comment|1216|||Dominion
+set_comment|1217|||Dominion (Upgraded)
+set_comment|1218|||Dominion - Airborne
+set_comment|1219|||Dominion - Airborne
+set_comment|1224|||Voice of God
+set_comment|1227|||Voice of God - Airborne (Upgraded)
+set_comment|1230|||Cancel
+set_comment|1239|||Ultimate Demise
+set_comment|1240|||Ultimate Demise (Upgraded)
+set_comment|1241|||Ultimate Demise - Airborne
+set_comment|1242|||Ultimate Demise - Airborne
 set_comment|1610|||
 set_comment|1611|||Yell
+set_comment|50002|||*Phoenix: Normal Combo: 01
+set_comment|50004|||*Phoenix: Burst Combo: 01
+set_comment|50005|||*Phoenix: Reincarnation Flame
+set_comment|52062|||*Ifrit Garuda Battle: Ifrit: Triangle Single Shot
+set_comment|52063|||*Ifrit Garuda Battle: Ifrit: Circle Lunge
+set_comment|54045|||*PC Ifrit: Lunge Attack
+set_comment|54054|||*PC Ifrit: Falling Attack - Airborne
+set_comment|54057|||*PC Ifrit: Falling Attack - Airborne (Upgraded)
+set_comment|54065|||*PC Ifrit: Charge Attack
+set_comment|54066|||*PC Ifrit: Charge Attack - Airborne (Upgraded)
+set_comment|54068|||Fireball
+set_comment|54069|||Fireball - Airborne (Upgraded)
+set_comment|54074|||Firaball
+set_comment|54075|||Firaball - Airborne (Upgraded)
+set_comment|54077|||Brimstone
+set_comment|54079|||*PC Ifrit: Titan Technique: Loop
+set_comment|54081|||Cancel
+set_comment|54082|||*PC Ifrit: Titan Technique: Activation: LV1
+set_comment|54083|||*PC Ifrit: Titan Technique: Activation: LV2
+set_comment|54084|||*PC Ifrit: Titan Technique: Activation: Just
+set_comment|54085|||Brimstone - Airborne (Upgraded)
+set_comment|54087|||*PC Ifrit: Titan Technique: Loop - Airborne (Upgraded)
+set_comment|54089|||Cancel - Airborne (Upgraded)
+set_comment|54090|||*PC Ifrit: Titan Technique: Activation: LV1 - Airborne (Upgraded)
+set_comment|54091|||*PC Ifrit: Titan Technique: Activation: LV2 - Airborne (Upgraded)
+set_comment|54092|||*PC Ifrit: Titan Technique: Activation: Just - Airborne (Upgraded)
+set_comment|54094|||Spitflare
+set_comment|54096|||Cancel
+set_comment|54097|||Spitflare - Airborne (Upgraded)
+set_comment|54099|||Cancel - Airborne (Upgraded)
+set_comment|54101|||Wildfire
+set_comment|54102|||Wildfire - Airborne (Upgraded)
+set_comment|54104|||*PC Ifrit: Circle Dash: End
+set_comment|54105|||*PC Ifrit: Circle Dash: End - Airborne (Upgraded)
+set_comment|54108|||*PC Ifrit: Titan P2: Normal Shot *AND* PC Ifrit: Titan P2: Normal Shot - Airborne
+set_comment|54113|||*PC Ifrit: Titan P2: Charge Shot: Fire
+set_comment|54114|||*PC Ifrit: Titan P2: Charge Shot: Fire - Airborne (Upgraded)
+set_comment|54123|||*PC Ifrit: Titan P4: Normal Shot - Airborne
+set_comment|54128|||*PC Ifrit: Titan P4: Charge Shot: Fire - Airborne
+set_comment|54148|||*PC Ifrit: Titan P5: Lunge Attack - Airborne
+set_comment|54157|||*PC Ifrit: Titan P5: Charge Attack - Airborne
+set_comment|54158|||Firaball - Airborne
+set_comment|54160|||Brimstone - Airborne
+set_comment|54162|||*PC Ifrit: Titan P5: Titan Technique: Loop - Airborne
+set_comment|54164|||Cancel - Airborne
+set_comment|54165|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV1 - Airborne
+set_comment|54166|||*PC Ifrit: Titan P5: Titan Technique: Activation: LV2 - Airborne
+set_comment|54167|||*PC Ifrit: Titan P5: Titan Technique: Activation: Just - Airborne
+set_comment|54169|||Spitflare - Airborne
+set_comment|54171|||Cancel - Airborne
+set_comment|54173|||Wildfire - Airborne
+set_comment|54175|||*PC Ifrit: Titan P5: Circle Dash: End - Airborne
+set_comment|54179|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start
+set_comment|54181|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop
+set_comment|54183|||Cancel
+set_comment|54184|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1
+set_comment|54185|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2
+set_comment|54186|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just
+set_comment|54187|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Start - Airborne (Upgraded)
+set_comment|54189|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Loop - Airborne (Upgraded)
+set_comment|54191|||Cancel - Airborne (Upgraded)
+set_comment|54192|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV1 - Airborne (Upgraded)
+set_comment|54193|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: LV2 - Airborne (Upgraded)
+set_comment|54194|||*PC Ifrit: Phoenix Cooperation: Titan Technique: Activation: Just - Airborne (Upgraded)
+set_comment|54198|||Cancel
+set_comment|54201|||Cancel - Airborne (Upgraded)
+set_comment|54227|||*PC Ifrit: Leviathan P1: Lunge Attack
+set_comment|54236|||*PC Ifrit: Leviathan P1: Charge Attack
+set_comment|54237|||Firaball
+set_comment|54239|||Brimstone
+set_comment|54241|||*PC Ifrit: Leviathan P1: Titan Technique: Loop
+set_comment|54243|||Cancel
+set_comment|54244|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV1
+set_comment|54245|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: LV2
+set_comment|54246|||*PC Ifrit: Leviathan P1: Titan Technique: Activation: Just
+set_comment|54249|||Spitflare
+set_comment|54251|||Cancel
+set_comment|54253|||Wildfire
+set_comment|54255|||*PC Ifrit: Leviathan P1: Circle Dash: End
+set_comment|59020|||*Ifrit Risen: Lunge Attack
+set_comment|59029|||*Ifrit Risen: Charge Attack
+set_comment|59031|||Fireballs
+set_comment|59033|||Firabeam
+set_comment|59035|||Brimstone
+set_comment|59037|||*Ifrit Risen: Titan Technique: Charge Complete
+set_comment|59039|||Cancel
+set_comment|59040|||*Ifrit Risen: Titan Technique: Activation: LV1
+set_comment|59041|||*Ifrit Risen: Titan Technique: Activation: LV2
+set_comment|59042|||*Ifrit Risen: Titan Technique: Activation: Just
+set_comment|59044|||Spitflare
+set_comment|59046|||Cancel
+set_comment|59048|||Wildfire
+set_comment|59050|||*Ifrit Risen: Circle Dash: End
+set_comment|59052|||Lightspeed


### PR DESCRIPTION
Added a bunch of comments to the `actions` nex file, by copying the command name from the `command` table

Notes:

- There were already some comments in the actions file, since they were manually added I left them since they are usually more detailed
- The existing comments used ` | Upgraded` for the upgraded actions, but this syntax breaks with the comments sytax so this is left out of the final comment in the SQL file, I changed it to (Upgaded), might be worth fixing the comment parsing to throw an error if it detects too many | split parts
- Actions from the "AirborneActionIds" column are marked with "airborne"
- Any action that is in the 3rd array position is marked as "upgraded"
- In rare cases where an action maps to two commands, I just added them as X *AND* Y
- There are a bunch of commands that only had jp description, so I just added the machine translation of them, all of them are marked by starting with *

Query:
```sql
WITH command_moves AS (
    SELECT '(FF16Tools): ' || group_concat(command_name || CASE WHEN is_upgraded THEN ' (Upgraded)' ELSE '' END, ' *AND* ') AS command_name,
           action_id
      FROM (
               SELECT coalesce(X.Name, X.Comment) AS command_name,
                      Y.value AS action_id,
                      Y.key == 2 AS is_upgraded
                 FROM command AS X,
                      json_each(json(X.GroundActionIds) ) AS Y
               UNION
               SELECT coalesce(X.Name, X.Comment) || ' - Airborne' AS command_name,
                      Y.value AS action_id,
                      Y.key == 2 AS is_upgraded
                 FROM command AS X,
                      json_each(json(X.AirborneActionIds) ) AS Y
           )
     WHERE command_name IS NOT NULL
     GROUP BY action_id
)
SELECT Key,
       coalesce(Comment, command_name) AS Comment
  FROM command_moves
       JOIN
       output3.action ON action_id == Key
 ORDER BY Key ASC;
```