### PR TITLE
FFT: Ivalice Chronicles support

### DIFF
--- a/FF16Tools.CLI/Program.cs
+++ b/FF16Tools.CLI/Program.cs
@@ -328,7 +328,7 @@ public class Program
 
         var builder = new FF16PackBuilder(new PackBuildOptions()
         {
-            CodeName = verbs.GameType,
+            CodeName = codeName,
             Compress = !verbs.NoCompress,
             Encrypt = verbs.Encrypt,
             Name = verbs.Name,

--- a/FF16Tools.Pack/Crypto/PackKeyStore.cs
+++ b/FF16Tools.Pack/Crypto/PackKeyStore.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FF16Tools.Pack.Crypto;
+
+/// <summary>
+/// Pack key registry.
+/// </summary>
+public class PackKeyStore
+{
+    /// <summary>
+    /// FINAL FANTASY XVI / 16
+    /// </summary>
+    public const string FFXVI_CODENAME = "faith";
+
+    /// <summary>
+    /// FINAL FANTASY TACTICS - The Ivalice Chronicles
+    /// </summary>
+    public const string FFT_IVALICE_CODENAME = "ffto";
+
+    public static readonly FrozenDictionary<string, ulong> Keys = new Dictionary<string, ulong>()
+    {
+        [FFXVI_CODENAME] = 0x49D18FC870F3824E,
+        [FFT_IVALICE_CODENAME] = 0x534C8F9A54D612E6,
+    }.ToFrozenDictionary();
+}

--- a/FF16Tools.Pack/Crypto/XorEncrypt.cs
+++ b/FF16Tools.Pack/Crypto/XorEncrypt.cs
@@ -10,30 +10,28 @@ namespace FF16Tools.Pack.Crypto;
 
 public class XorEncrypt
 {
-    public const ulong XOR_KEY = 0x49D18FC870F3824E;
-
-    public static void CryptHeaderPart(Span<byte> data)
+    public static void CryptHeaderPart(Span<byte> data, ulong key)
     {
         Span<byte> cur = data;
         while (cur.Length >= 8)
         {
-            MemoryMarshal.Cast<byte, ulong>(cur)[0] ^= XOR_KEY;
+            MemoryMarshal.Cast<byte, ulong>(cur)[0] ^= key;
             cur = cur[8..];
         }
 
         if (cur.Length >= 4)
         {
-            MemoryMarshal.Cast<byte, uint>(cur)[0] ^= (uint)(XOR_KEY & 0xFFFFFFFF);
+            MemoryMarshal.Cast<byte, uint>(cur)[0] ^= (uint)(key & 0xFFFFFFFF);
             cur = cur[4..];
         }
 
         if (cur.Length >= 2)
         {
-            MemoryMarshal.Cast<byte, ushort>(cur)[0] ^= (ushort)(XOR_KEY & 0xFFFF);
+            MemoryMarshal.Cast<byte, ushort>(cur)[0] ^= (ushort)(key & 0xFFFF);
             cur = cur[2..];
         }
 
         if (cur.Length >= 1)
-            cur[0] ^= (byte)(XOR_KEY & 0xFF);
+            cur[0] ^= (byte)(key & 0xFF);
     }
 }

--- a/FF16Tools.Pack/FF16PackManager.cs
+++ b/FF16Tools.Pack/FF16PackManager.cs
@@ -29,7 +29,10 @@ public class FF16PackManager : IDisposable, IAsyncDisposable
     /// Opens a directory containing pack files.
     /// </summary>
     /// <param name="directory">Directory containing pack files. Normally 'data' folder.</param>
-    public void Open(string directory)
+    /// <param name="codeName">Codename, used to determine the decryption key to use.<br/>
+    /// Valid codenames are 'faith' (FFXVI), 'ffto' (FFT).
+    /// </param>
+    public void Open(string directory, string codeName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(directory, nameof(directory));
 
@@ -37,7 +40,7 @@ public class FF16PackManager : IDisposable, IAsyncDisposable
         {
             try
             {
-                FF16Pack pack = FF16Pack.Open(file);
+                FF16Pack pack = FF16Pack.Open(file, codeName);
                 _packFiles.Add(Path.GetFileNameWithoutExtension(file), pack);
             }
             catch (Exception ex)

--- a/FF16Tools.Pack/Packing/PackBuildOptions.cs
+++ b/FF16Tools.Pack/Packing/PackBuildOptions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using FF16Tools.Pack.Crypto;
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +10,14 @@ namespace FF16Tools.Pack.Packing;
 
 public class PackBuildOptions
 {
+    /// <summary>
+    /// Codename to pack for. Used to determine the encryption key to use.<br/>
+    /// Valid codenames are 'faith' (FFXVI), 'ffto' (FFT).<br/>
+    /// <br/>
+    /// Defaults to 'faith' (FF16).
+    /// </summary>
+    public string CodeName { get; set; } = PackKeyStore.FFXVI_CODENAME;
+ 
     private string? _name;
     public string? Name
     {


### PR DESCRIPTION
Adds support for FINAL FANTASY TACTICS - The Ivalice Chronicles.

Requires supplying a new `--gametype` argument when unpacking and packing, as the crypto key cannot be inferred.